### PR TITLE
远程元存储模式下关闭身份验证, 解决无法使用beeline连接hive

### DIFF
--- a/hive3.1.2/conf/hive-site.xml
+++ b/hive3.1.2/conf/hive-site.xml
@@ -23,4 +23,5 @@
   <property><name>javax.jdo.option.ConnectionUserName</name><value>hive</value></property>
   <property><name>javax.jdo.option.ConnectionDriverName</name><value>org.postgresql.Driver</value></property>
   <property><name>hive.execution.engine</name><value>tez</value></property>
+  <property><name>hive.metastore.event.db.notification.api.auth</name><value>false</value></property>
 </configuration>


### PR DESCRIPTION

“ hive.metastore.event.db.notification.api.auth”，默认情况下设置为 true

auth 机制的工作原理如下：

不管“ hive.metastore.event.db.notification.api.auth”设置如何，都可以在嵌入式 metasore 模式下跳过身份验证
原因是我们知道 metastore 调用是由配置单元发出的，而不是其他正在运行 metastoreClient 端的未经授权的进程。

如果“ hive.metastore.event.db.notification.api.auth”设置为 true，则在远程元存储模式下启用身份验证
远程 metastoreClient 端的 UGI 始终在 metastore 服务器上设置。我们检索该用户信息，并根据[proxy user](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/Superusers.html)设置检查该用户是否具有代理权限。例如，UGI 是用户“ hive”，“ hive”已配置为对主机列表具有代理特权。然后，身份验证将通过这些主机的通知相关呼叫。如果用户“ foo”正在执行 repl 操作(例如，通过带有 doAs = true 的 HS2)，则除非用户“ foo”配置为具有代理特权，否则身份验证将失败。